### PR TITLE
Replace deprecated inputstreamaddon with inputstream

### DIFF
--- a/lib/libmediathek4.py
+++ b/lib/libmediathek4.py
@@ -250,7 +250,7 @@ class lm4:
 				streamType = 'AUDIO'
 		listitem = xbmcgui.ListItem(path=url)
 		if streamType == 'DASH':
-			listitem.setProperty('inputstreamaddon', 'inputstream.adaptive')
+			listitem.setProperty('inputstream', 'inputstream.adaptive')
 			listitem.setProperty('inputstream.adaptive.manifest_type', 'mpd')
 			if 'licenseserverurl' in item:
 				listitem.setProperty('inputstream.adaptive.license_type', 'com.widevine.alpha')
@@ -260,7 +260,7 @@ class lm4:
 			listitem.setContentLookup(False)
 		elif streamType == 'HLS':
 			listitem.setMimeType('application/vnd.apple.mpegurl')
-			listitem.setProperty('inputstreamaddon', 'inputstream.adaptive')
+			listitem.setProperty('inputstream', 'inputstream.adaptive')
 			listitem.setProperty('inputstream.adaptive.manifest_type', 'hls')
 			listitem.setContentLookup(False)
 		#elif streamType == 'MP4':


### PR DESCRIPTION
According to https://forum.kodi.tv/showthread.php?tid=353560 `inputstreamaddon` is deprecated in favor of `inputstream`.
This fixes the following error e. g. when trying to play a dash stream using the filmfriend plugin:

```
ERROR <general>: CInputStreamAddon::Supports - 'inputstreamaddon' has been deprecated, please use `#KODIPROP:inputstream=inputstream.adaptive` instead
INFO <general>: Python interpreter stopped
INFO <general>: Creating Demuxer
ERROR <general>: Open - error probing input format, https://ak01-flm.delivery.fuugo.com/filmleihe/filme/i_am_love/i_am_love.mpd
ERROR <general>: OpenDemuxStream - Error creating demuxer
```